### PR TITLE
Diff the CloudFormation stacks on PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,93 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI-pull-request
+
+# Controls when the action will run.
+on:
+  # Triggers the workflow on PR to master
+  pull_request:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Install
+        run: |
+          npm install
+
+      - name: Install frontend
+        working-directory: frontend
+        run: |
+          npm install
+
+      - name: Install backend/connect
+        working-directory: backend/connect
+        run: |
+          npm install
+
+      - name: Build
+        run: |
+          npm run build
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm run build
+
+      - name: Test frontend
+        working-directory: frontend
+        run: |
+          npm test
+
+      - name: Test
+        run: |
+          npm run test -- test
+
+      - name: Identify test account and region
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+        run: |
+          aws sts get-caller-identity
+          echo ${AWS_DEFAULT_REGION} | sed 's/-/+/g'
+
+      - name: Diff the test account
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+        run: |
+          npx cdk diff
+
+      - name: Identify prod account and region
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+        run: |
+          aws sts get-caller-identity
+          echo ${AWS_DEFAULT_REGION} | sed 's/-/+/g'
+
+      - name: Diff the prod account
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-east-1"
+        run: |
+          npx cdk diff


### PR DESCRIPTION
Inspired by https://github.com/douglasnaphas/madliberation/issues/343.

This prints a `cdk diff` in the test account and prod account on PRs.

That way, when someone raises a PR, you can see what changes will be
made to your AWS resources in the test and prod account if the PR is
merged.

Similarly, if you want to see how a change will affect your resources,
you can raise a PR with the change, and look at the GitHub Actions
output for the PR build.

Note that we don't want to deploy any resources in PR builds, because
then someone could come along and create some expensive resource in a
PR, and it would get created in an account under our control.

Here is an example of a PR build with `cdk diff` in action:

https://github.com/douglasnaphas/madliberation/pull/344/checks?check_run_id=2903164159